### PR TITLE
audit: Refactor function visibility for clarity

### DIFF
--- a/contracts/MCV2_MultiToken.sol
+++ b/contracts/MCV2_MultiToken.sol
@@ -39,7 +39,7 @@ contract MCV2_MultiToken is ERC1155Initializable {
     /* @dev Mint tokens by bonding curve contract
      * Minting should also provide liquidity to the bonding curve contract
      */
-    function mintByBond(address to, uint256 amount) public onlyBond {
+    function mintByBond(address to, uint256 amount) external onlyBond {
         totalSupply += amount;
         _mint(to, 0, amount, "");
     }
@@ -47,7 +47,7 @@ contract MCV2_MultiToken is ERC1155Initializable {
     /* @dev Direct burn function call is disabled because it affects the bonding curve.
      * Users can simply send tokens to the token contract address for the same burning effect without changing the totalSupply.
      */
-    function burnByBond(address account, uint256 amount) public onlyBond {
+    function burnByBond(address account, uint256 amount) external onlyBond {
         if (amount > totalSupply) revert MCV2_MultiToken__BurnAmountExceedsTotalSupply();
         if(!isApprovedForAll(account, bond)) revert MCV2_MultiToken__NotApproved(); // `msg.sender` is always be `_bond`
 

--- a/contracts/MCV2_Token.sol
+++ b/contracts/MCV2_Token.sol
@@ -27,14 +27,14 @@ contract MCV2_Token is ERC20Initializable {
     /* @dev Mint tokens by bonding curve contract
      * Minting should also provide liquidity to the bonding curve contract
      */
-    function mintByBond(address to, uint256 amount) public onlyBond {
+    function mintByBond(address to, uint256 amount) external onlyBond {
         _mint(to, amount);
     }
 
     /* @dev Direct burn function call is disabled because it affects the bonding curve.
      * Users can simply send tokens to the token contract address for the same burning effect without changing the totalSupply.
      */
-    function burnByBond(address account, uint256 amount) public onlyBond {
+    function burnByBond(address account, uint256 amount) external onlyBond {
         _spendAllowance(account, bond, amount); // `msg.sender` is always be `bond`
         _burn(account, amount);
     }


### PR DESCRIPTION
**Recommendation:** Refactor function visibility for clarity in contract code

This commit updates the visibility of certain functions from 'public' to 'external' in our Solidity contracts. The primary goal of this change is to enhance the clarity and readability of the code by clearly indicating that these functions are intended for external calls only. This adjustment aligns with best practices in contract development, making our codebase more understandable and maintainable.

**Updated functions:**
- `mintByBond` and `burnByBond` in MCV2_Token contract
- `mintByBond` and `burnByBond` in MCV2_MultiToken contract

No significant gas optimization or resolving an issue is expected from this change, but the improved clarity in function visibility aids in better understanding and usage of the contract interfaces.