### PR TITLE
gas optimization for MCV2_Bond::_setBond() function

### DIFF
--- a/contracts/MCV2_Bond.sol
+++ b/contracts/MCV2_Bond.sol
@@ -189,16 +189,18 @@ contract MCV2_Bond is MCV2_Royalty {
         bond.reserveToken = bp.reserveToken;
 
         for (uint256 i = 0; i < bp.stepRanges.length; ++i) {
-            if (bp.stepRanges[i] == 0) revert MCV2_Bond__InvalidStepParams('STEP_CANNOT_BE_ZERO');
+            uint128 _stepRange = bp.stepRanges[i];
+
+            if (_stepRange == 0) revert MCV2_Bond__InvalidStepParams('STEP_CANNOT_BE_ZERO');
 
             // Ranges and prices must be strictly increasing
             if (i > 0) {
-                if (bp.stepRanges[i] <= bp.stepRanges[i - 1]) revert MCV2_Bond__InvalidStepParams('DECREASING_RANGE');
+                if (_stepRange <= bp.stepRanges[i - 1]) revert MCV2_Bond__InvalidStepParams('DECREASING_RANGE');
                 if (bp.stepPrices[i] <= bp.stepPrices[i - 1]) revert MCV2_Bond__InvalidStepParams('DECREASING_PRICE');
             }
 
             bond.steps.push(BondStep({
-                rangeTo: bp.stepRanges[i],
+                rangeTo: _stepRange,
                 price: bp.stepPrices[i]
             }));
         }


### PR DESCRIPTION
I don't know how much you are interested in this kind of gas optimization, but this change reduces the gas :

Before:

```
······················|·····························|·············|·············|···············|················
|  MCV2_Bond          ·  createMultiToken           ·     391375  ·     492578  ·       488539  ·           73  │
······················|·····························|·············|·············|···············|················
|  MCV2_Bond          ·  createToken                ·     295461  ·     524695  ·       510168  ·          105  │
····················································|·············|·············|···············|················
|  Deployments                                      ·                                           ·  % of limit   │
····················································|·············|·············|···············|················
|  MCV2_Bond                                        ·    4906856  ·    4906880  ·      4906864  ·       16.4 %  │
····················································|·············|·············|···············|···············
```

After:

```
······················|·····························|·············|·············|···············|················
|  MCV2_Bond          ·  createMultiToken           ·     390345  ·     490166  ·       486174  ·           73  │
······················|·····························|·············|·············|···············|················
|  MCV2_Bond          ·  createToken                ·     295122  ·     519519  ·       505289  ·          105  │
····················································|·············|·············|···············|················
|  Deployments                                      ·                                           ·  % of limit   │
····················································|·············|·············|···············|················
|  MCV2_Bond                                        ·    4886976  ·    4887000  ·      4886984  ·       16.3 %  │
····················································|·············|·············|···············|················
```


__NEW GAS CONSUMPTION__
```
·---------------------------------------------------|---------------------------|---------------|-----------------------------·
|               Solc version: 0.8.20                ·  Optimizer enabled: true  ·  Runs: 50000  ·  Block limit: 30000000 gas  │
····················································|···························|···············|······························
|  Methods                                                                                                                    │
······················|·····························|·············|·············|···············|···············|··············
|  Contract           ·  Method                     ·  Min        ·  Max        ·  Avg          ·  # calls      ·  usd (avg)  │
······················|·····························|·············|·············|···············|···············|··············
|  Locker             ·  createLockUp               ·     118371  ·     177007  ·       147544  ·           40  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  Locker             ·  unlock                     ·      65465  ·      66722  ·        66024  ·            9  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  burn                       ·      94980  ·     129799  ·       117829  ·           42  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  burnRoyalties              ·          -  ·          -  ·        79820  ·            1  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  claimRoyalties             ·          -  ·          -  ·        80096  ·            3  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  createMultiToken           ·     390345  ·     490166  ·       486174  ·           73  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  createToken                ·     295122  ·     519519  ·       505289  ·          105  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  mint                       ·     108597  ·     208272  ·       190540  ·           98  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  updateBondCreator          ·      26272  ·      29084  ·        28305  ·           15  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  updateCreationFee          ·      46873  ·      46885  ·        46880  ·            5  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  updateProtocolBeneficiary  ·          -  ·          -  ·        30049  ·            1  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Bond          ·  updateTokenMetaData        ·      39934  ·     118836  ·        92535  ·            6  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_MultiToken    ·  safeTransferFrom           ·          -  ·          -  ·        37867  ·            1  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_MultiToken    ·  setApprovalForAll          ·          -  ·          -  ·        48812  ·           20  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Token         ·  approve                    ·      49012  ·      49312  ·        49210  ·           29  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MCV2_Token         ·  transfer                   ·          -  ·          -  ·        32280  ·            1  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MerkleDistributor  ·  claim                      ·      91728  ·      97832  ·        95802  ·           30  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MerkleDistributor  ·  createDistribution         ·     140040  ·     203810  ·       188389  ·           67  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  MerkleDistributor  ·  refund                     ·      47640  ·      48950  ·        48295  ·            6  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  TaxToken           ·  approve                    ·          -  ·          -  ·        46634  ·            4  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  TaxToken           ·  transfer                   ·          -  ·          -  ·        54349  ·            4  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  TestMultiToken     ·  setApprovalForAll          ·      26214  ·      46114  ·        45511  ·           33  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  TestToken          ·  approve                    ·      24327  ·      46611  ·        46046  ·          164  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  TestToken          ·  transfer                   ·      34354  ·      51490  ·        50459  ·          113  ·          -  │
······················|·····························|·············|·············|···············|···············|··············
|  Deployments                                      ·                                           ·  % of limit   ·             │
····················································|·············|·············|···············|···············|··············
|  Locker                                           ·          -  ·          -  ·      1277823  ·        4.3 %  ·          -  │
····················································|·············|·············|···············|···············|··············
|  MCV2_Bond                                        ·    4886976  ·    4887000  ·      4886984  ·       16.3 %  ·          -  │
····················································|·············|·············|···············|···············|··············
|  MCV2_MultiToken                                  ·          -  ·          -  ·      1955155  ·        6.5 %  ·          -  │
····················································|·············|·············|···············|···············|··············
|  MCV2_Token                                       ·          -  ·          -  ·       858512  ·        2.9 %  ·          -  │
····················································|·············|·············|···············|···············|··············
|  MerkleDistributor                                ·          -  ·          -  ·      1975319  ·        6.6 %  ·          -  │
····················································|·············|·············|···············|···············|··············
|  TaxToken                                         ·          -  ·          -  ·       736527  ·        2.5 %  ·          -  │
····················································|·············|·············|···············|···············|··············
|  TestMultiToken                                   ·    1380918  ·    1380930  ·      1380924  ·        4.6 %  ·          -  │
····················································|·············|·············|···············|···············|··············
|  TestToken                                        ·     659419  ·     679683  ·       677296  ·        2.3 %  ·          -  │
·---------------------------------------------------|-------------|-------------|---------------|---------------|-------------·
```